### PR TITLE
Issue-29: cg-charter: clarify non-use of the "contrib" list

### DIFF
--- a/incubator-cg-charter.html
+++ b/incubator-cg-charter.html
@@ -85,6 +85,8 @@
 
 <p>Terms of in this charter that conflict with those of the <a href="https://www.w3.org/community/about/agreements/">Community and Business Group Process</a> are void.</p>
 
+<p>Note: this CG will not use a <em></em>contrib</em> e-mail list for contributions since all contributions will be tracked via Github mechanisms (f.ex. pull requests).</p>
+
 <h2 id="contrib">Contribution Mechanics</h2>
 
 <p>Community Group participants agree to make contributions in the GitHub repo for the project that they are interested in. This may be in the form of a pull request (preferred), by raising an issue, or by adding a comment to an existing issue.</p>


### PR DESCRIPTION
This PR is for Issue-29 https://github.com/w3c/charter-html/issues/29
