### PR TITLE
[charter] typo and latest w3c software license

### DIFF
--- a/incubator-cg-charter.html
+++ b/incubator-cg-charter.html
@@ -34,7 +34,7 @@
 
 <p>As proposals gain support and become more stable and mature they will be considered for migration to a W3C Working Group where they can be put on the Recommendation track with appropriate status and Intellectual Property (IP) considerations.</p>
 
-<p>Individuals, after consultation with the Chairs, may prepare a "<a href="request-to-transition.html">intent to migrate</a>" assessment, outlining use cases, as well as implementation considerations, security, privacy, accessibility, and internationalisation impacts. Those requests are evaluated within the Community Group as well the targeted W3C Working Group, if any.  The role of the CG and WG Chairs and W3C team is to facilitate the migration and ensure proper continuity in the community who proposed the idea.</p>
+<p>Individuals, after consultation with the Chairs, may prepare an "<a href="request-to-transition.html">intent to migrate</a>" assessment, outlining use cases, as well as implementation considerations, security, privacy, accessibility, and internationalisation impacts. Those requests are evaluated within the Community Group as well the targeted W3C Working Group, if any.  The role of the CG and WG Chairs and W3C team is to facilitate the migration and ensure proper continuity in the community who proposed the idea.</p>
 
 <h2 id="background">Background</h2>
 
@@ -64,7 +64,7 @@
 
 <h2 id="proposals">Current Proposals</h2>
 
-<p>The group publishes an <a href="https://example.com/indexpage">index of the proposals</a> worked on in GitHub. Any <a href="https://www.safaribooksonline.com/library/view/building-polyfills/9781449370725/ch07.html">prollyfills</a> or test suites will be developed in Open Source using the <a href="http://www.w3.org/Consortium/Legal/2002/copyright-software-20021231">W3C Software License</a>.</p>
+<p>The group publishes an <a href="https://example.com/indexpage">index of the proposals</a> worked on in GitHub. Any <a href="https://www.safaribooksonline.com/library/view/building-polyfills/9781449370725/ch07.html">prollyfills</a> or test suites will be developed in Open Source using the <a href="http://www.w3.org/Consortium/Legal/2015/copyright-software-and-document">W3C Software and Document License</a>.</p>
 
 <p>New projects or status changes are communicated to the group through the public announcement mailing list (this list will not be used for discussing proposals).</p>
 


### PR DESCRIPTION
There is a new W3C Software License.  One reference in the proposed CG charter linked to the new version of the license. The other linked to the old one.  Also fixed a typo 'a "intent to migrate"' should be 'an'.
