### PR TITLE
Add WebApps WG to the set of dependent groups

### DIFF
--- a/timed-media-wg.html
+++ b/timed-media-wg.html
@@ -155,6 +155,8 @@
       <dd>This group creates API specifications for controlling secondary screens for displaying web coment. The Timed Media Working Group may provide APIs to project media through a secondary screen.</dd>
       <dt><a href="http://www.w3.org/WAI/PF/">WAI Protocols and Formats Working Group</a></dt>
       <dd>To ensure that Timed Media WG deliverables appropriately support accessibility requirements.</dd>
+      <dt><a href="http://www.w3.org/2008/webapps/">Web Applications (WebApps) Working Group</a></dt>
+      <dd>This group is working on dependencies such as Web IDL.</dd>
       <dt><a href="http://www.w3.org/International/core/">Internationalization Core Working Group</a></dt>
       <dd>This group may provide advice or review to ensure that Timed Media WG deliverables meet the needs of an international Web.</dd>
       <dt><a href="http://www.w3.org/Privacy/" shape="rect">Privacy Interest Group</a></dt>


### PR DESCRIPTION
The specs in the proposed WG normatively reference at least WebApps' Web IDL spec, thus WebApps should be included in the set of dependent WGs.
