### PR TITLE
[CG Charter] fixed typos

### DIFF
--- a/incubator-cg-charter.html
+++ b/incubator-cg-charter.html
@@ -56,7 +56,7 @@
 
 <h2 id="scope">Scope of Work</h2>
 
-<p>The community group will accept and discuss any proposal for a web platform feature that would be implemented in a browser or similar user agent. Any suggestions, pull requests, issues, or comments made about a proposal fall under the CLA. Editors of feature proposals must ensure that no contributions are adopted from anyone who is not a member of the community group.</p>
+<p>The Community Group will accept and discuss any proposal for a web platform feature that would be implemented in a browser or similar user agent. Any suggestions, pull requests, issues, or comments made about a proposal fall under the CLA. Editors of feature proposals must ensure that no contributions are adopted from anyone who is not a member of the Community Group.</p>
 
 <h2 id="nonscope">Out of Scope</h2>
 
@@ -83,7 +83,7 @@
 
 <h2 id="process">Community and Business Group Process and Patent Policy</h2>
 
-<p>The group operates under the <a href="https://www.w3.org/community/about/agreements/">Community and Business Group Process</a> Terms of in this charter that conflict with those of the Community and Business Group Process are void.</p>
+<p>The group operates under the <a href="https://www.w3.org/community/about/agreements/">Community and Business Group Process</a>. Terms of in this charter that conflict with those of the Community and Business Group Process are void.</p>
 
 <p>
 As with other Community Groups, W3C seeks organizational licensing commitments under the <a href='http://www.w3.org/community/about/agreements/cla/'>W3C Community Contributor License Agreement (CLA)</a> (Proposals in this Community Group charter are applicable "Specification" in the CLA). When people request to participate without representing their organization’s legal interests, W3C


### PR DESCRIPTION
s/community group/Community Group/ and a missing ","
