### PR TITLE
Remove "Activity" info

### DIFF
--- a/group-charter.html
+++ b/group-charter.html
@@ -56,8 +56,7 @@
       <h1 id="title">[DRAFT] Web Platform Working Group Charter</h1>
 
       <p class="mission">The mission of the <a href="@@">Web
-          Platform Working Group</a>, part of the <a href="http://www.w3.org/2006/rwc/">Rich
-          Web Client Activity</a>,  is to continue the development of the HTML language, providing specifications that enable
+          Platform Working Group</a> is to continue the development of the HTML language, providing specifications that enable
         improved client-side application development on the Web, including
          <em>application programming interfaces (APIs)
           for client-side development</em> and <em>markup vocabularies for


### PR DESCRIPTION
Remove info about the Rich Web Client Activity since "Activities" are no longer part of the consortium's informal processes (and `Rich Web Client` is now a mostly "dated" term).
