### PR TITLE
Topic-specific f2f meetings may be "formal"

### DIFF
--- a/group-charter.html
+++ b/group-charter.html
@@ -94,7 +94,7 @@
               may be held up to once per week<br />
               Face-to-face: we will meet during the W3C's annual Technical
               Plenary week; other F2F meetings may be scheduled (up to 2 per year for the full
-              group, or additional informal meetings of subgroups working on specific
+              group, and/or additional meetings of subgroups working on specific
               topics.)<br />
               IRC: active participants, particularly editors, regularly use the
               #webapps W3C IRC channel </td>


### PR DESCRIPTION
The current text indicates topic-specific f2f meetings are always "informal" whereas they may indeed be "formal" meetings.
