### PR TITLE
Use 2014 confidentiality reference

### DIFF
--- a/group-charter.html
+++ b/group-charter.html
@@ -77,7 +77,7 @@
           </tr>
           <tr>
             <th>Confidentiality</th>
-            <td>Proceedings are <a href="http://www.w3.org/2005/10/Process-20051014/comm.html#confidentiality-levels">Public</a></td>
+            <td>Proceedings are <a href="http://www.w3.org/2014/Process-20140801/#confidentiality-levels">Public</a></td>
           </tr>
           <tr>
             <th>Chairs</th>


### PR DESCRIPTION
The draft charter references the 2005 process document for the reference to Public Confidentiality and it should refer to the 2014 process document.
