### PR TITLE
Use consistent casing with unordered lists

### DIFF
--- a/group-charter.html
+++ b/group-charter.html
@@ -111,13 +111,13 @@
       </div>
       <div id="scope">
         <h2>Scope</h2>
-        <p>The Web Platform Working Group will:</p>
+        <p>The group will:</p>
         <ul>
-          <li>continue the development of the HTML language, and associated APIs;</li>
-          <li>ensure that developers can use Web technologies to build client-side applications that rely on Web engines as application runtime environments;</li>
-          <li>provide generic and consistent interoperability and integration among all target formats, such as HTML, CSS, and SVG.</li>
-          <li>continue to define normative requirements for applications that process HTML resources, including (but not limited to) browsers and other interactive user agents, as well as authoring tools, markup generators, and conformance checkers;</li>
-          <li>ensure universal access to Web applications across a wide range of devices and among a diversity of users, by addressing issues of accessibility, device independence, internationalization, mobility, privacy, and security.</li>
+          <li>Continue the development of the HTML language, and associated APIs.</li>
+          <li>Ensure that developers can use Web technologies to build client-side applications that rely on Web engines as application runtime environments.</li>
+          <li>Provide generic and consistent interoperability and integration among all target formats, such as HTML, CSS, and SVG.</li>
+          <li>Continue to define normative requirements for applications that process HTML resources, including (but not limited to) browsers and other interactive user agents, as well as authoring tools, markup generators, and conformance checkers.</li>
+          <li>Ensure universal access to Web applications across a wide range of devices and among a diversity of users, by addressing issues of accessibility, device independence, internationalization, mobility, privacy, and security.</li>
         </ul>
 
         <p>


### PR DESCRIPTION
This PR uses Upper case at the start of the unordered items and a period to end each item, to be consistent with the unordered list (in Section 2.1) that follows.
