### PR TITLE
Fix IME API description

### DIFF
--- a/group-charter.html
+++ b/group-charter.html
@@ -232,9 +232,7 @@
           </dd>
           <dt><a href="https://w3c.github.io/ime-api/">Input
               Method (IME) API</a></dt>
-          <dd>A specification MAY to define an API to determine the input method being used, to improve the
-            internationalization of applications working with keyboard and text
-            entry. </dd>
+          <dd>This specification defines APIs that provide access to a (native) input method editor appication.</dd>
           <dt id="manifest"><a href="http://w3c.github.io/manifest/">Manifest for Web applications</a></dt>
           <dd>A JSON-based manifest, which provides developers with a
 	    centralized place to put metadata about a web application.</dd>


### PR DESCRIPTION
The description of the IME API spec contains some errors (probably as the result of a copy-pasta error). This PR proposes text based on the spec's Abstract.
