### PR TITLE
Web Workers uses Github

### DIFF
--- a/group-charter.html
+++ b/group-charter.html
@@ -304,7 +304,7 @@
           <dt id="webidl"><a href="http://heycam.github.io/webidl/">Web Interface
               Definition Language (Web IDL)</a></dt>
           <dd>Language bindings and types for Web interface descriptions.</dd>
-          <dt id="web-workers"><a title="Web Workers" href="http://dev.w3.org/html5/workers/">Web
+          <dt id="web-workers"><a title="Web Workers" href="https://w3c.github.io/workers/">Web
              Workers</a></dt>
           <dd>An API that allows Web application authors to spawn background
             workers running scripts in parallel to their main page, allowing for


### PR DESCRIPTION
This PR changes the Web Workers URL to the spec's Github location.
