### PR TITLE
Update data about Web Annotation joint deliverable

### DIFF
--- a/group-charter.html
+++ b/group-charter.html
@@ -271,8 +271,8 @@
       <dd>An API that provides web applications scripted access to server-sent notifications.</dd>
 	    <dt id="robust-anchoring">Robust Anchoring API</dt>
 		<dd>APIs for linking to a document selection, even when the document
-		has changed. This may be a joint deliverable with the proposed Web
-		Annotations WG.</dd>
+		has changed. This is a joint deliverable with the Web
+		Annotation WG.</dd>
           <dt id="screen-orientation"><a href="https://w3c.github.io/screen-orientation/">Screen Orientation API</a></dt>
           <dd>A view orientation and locking API e.g. to enable reading the
             view's orientation state, locking view orientation, notification of
@@ -493,6 +493,9 @@ during their development.
             assistive technologies, and inclusion in deliverables of guidance
             for implementing Web Platform deliverables in ways that support
             accessibility requirements. (This Group is expected to combine into an all-guidelines group in 2016 2Q).</dd>
+          <dt><a href="http://www.w3.org/annotation/">Web Annotation Working Group</a></dt>
+          <dd>The Web Platform Working Group has a joint deliverable with this group regarding
+            robust anchoring.</dd>	
           <dt><a href="http://www.w3.org/Mobile/IG/">Web and Mobile Interest Group</a></dt>
           <dd>This group may provide advice or review to ensure that Web Platform WG
             deliverables interact correctly in the context of Mobile applications.</dd>


### PR DESCRIPTION
This PR updates the information about the joint deliverable (Robust Anchoring) with the Web Annotation WG and adds that WG to list of liaisons. 

(WebAnnotWG has not yet published a TR for this deliverable, although the have started work on "RangeFinder API"; see https://www.w3.org/annotation/wiki/PubStatus).
