### PR TITLE
Resolutions at f2f meetings are provisional.

### DIFF
--- a/group-charter.html
+++ b/group-charter.html
@@ -608,12 +608,12 @@ during their development.
           decision, along with any objections. The matter should then be
           considered resolved unless and until new information becomes
           available.</p>
-        <p>Any resolution taken in a face-to-face meeting or teleconference is
+        <p><strong></strong>Any resolution taken in a face-to-face meeting or teleconference is
           to be considered provisional until 10 working days after the
           publication of the resolution in draft minutes sent to the working
-          groups mailing list. If no objections are raised on the mailing list
+          group's mailing list. If no objections are raised on the mailing list
           within that time, the resolution will be considered to have consensus
-          as a resolution of the Working Group. </p>
+          as a resolution of the Working Group.<strong></strong> </p>
         <p>This charter is written in accordance with <a href="http://www.w3.org/Consortium/Process/policies#Votes">Section
             3.4, Votes</a> of the W3C Process Document and includes no voting
           procedures beyond what the Process Document requires. </p>


### PR DESCRIPTION
This PR adds emphasis to the text that states resolutions at f2f meetings are provisional.
