### PR TITLE
Pointer Lock now uses Github

### DIFF
--- a/group-charter.html
+++ b/group-charter.html
@@ -275,7 +275,7 @@
           </dd>
           <dt id="packaging"><a href="http://w3ctag.github.io/packaging-on-the-web/">Packaging on the Web</a></dt>
           <dd>This document describes an approach for creating packages of files for use on the web.</dd>
-          <dt id="pointer-lock"><a href="http://dvcs.w3.org/hg/pointerlock/raw-file/tip/index.html">Pointer Lock</a></dt>
+          <dt id="pointer-lock"><a href="https://w3c.github.io/pointerlock/">Pointer Lock</a></dt>
           <dd>Defines APIs that provide scripted access to raw mouse movement data
 	    while locking the target of mouse events to a single element and removing
 	    the cursor from view.</dd>


### PR DESCRIPTION
The Pointer Lock spec now uses Github so the spec's URL must be updated accordingly.
