### PR TITLE
Various fixes

### DIFF
--- a/webplat-wg.html
+++ b/webplat-wg.html
@@ -70,7 +70,7 @@
         <li><a href="#decisions">Decision Policy</a></li>
         <li><a href="#patentpolicy">Patent Policy </a></li>
         <li><a href="#licensing">Licensing</a></li>
-        <li><a href="#about">About this Charter</a></li>
+        <li><a href="#about">About this Working Group charter</a></li>
       </ul>
       <p><a href="https://www.w3.org/"><img src="https://www.w3.org/Icons/w3c_home" alt="W3C" 
       height="48" width="72"></a> </p>
@@ -674,8 +674,8 @@
       edDB-2-20160818/</a><br>
         associated <a href="https://lists.w3.org/Archives/Member/member-cfe/2016Aug/0003.html">Call 
         for Exclusion</a> on 18 August 2016 ended on 15 January 2017
-        <br>Produced under Working Group Charter: 
-        https://www.w3.org/2015/10/webplatform-charter.html</dd>
+        <br>Produced under 
+        <a href="https://www.w3.org/2015/10/webplatform-charter.html">Web Platform Working Group charter</a></dd>
 
 <dt id=1357 class='spec'><a href='https://www.w3.org/TR/dom41/' rel='versionof'>W3C DOM 4.1</a>
  <br>Latest publication: <a href='https://www.w3.org/TR/2017/WD-dom41-20170420/'>20 April 
@@ -686,8 +686,8 @@ href='https://www.w3.org/TR/2017/WD-dom41-20170321/'>https://www.w3.org/TR/2017/
 a><br>
 associated <a href='https://lists.w3.org/Archives/Member/member-cfe/2017Mar/0002.html'> Call for 
 Exclusion</a> on 22 March 2017
-<br><i>Exclusion opportunity will end on 18 August 2017</i><br>Produced under Working Group Charter: 
-https://www.w3.org/2016/11/webplatform-charter.html</dd>
+<br><i>Exclusion opportunity will end on 18 August 2017</i><br>Produced under 
+<a href="https://www.w3.org/2016/11/webplatform-charter.html">Web Platform Working Group charter</a></dd>
 
 <dt id=952 class='spec'><a href='https://www.w3.org/TR/DOM-Parsing/' rel='versionof'>DOM Parsing and 
 Serialization</a>
@@ -699,8 +699,8 @@ href='https://www.w3.org/TR/2016/WD-DOM-Parsing-20160517/'>https://www.w3.org/TR
 0160517/</a><br>
 associated <a href='https://lists.w3.org/Archives/Member/member-cfe/2014May/0005.html'> Call for 
 Exclusion</a> on 01 May 2014
- ended on 30 June 2014<br>Produced under Working Group Charter: 
- https://www.w3.org/2012/webapps/charter/</dd>
+ ended on 30 June 2014<br>Produced under 
+ <a href="https://www.w3.org/2012/webapps/charter/">Web Applications Working Group charter</a></dd>
 
 <dt id=194 class='spec'><a href='https://www.w3.org/TR/uievents/' rel='versionof'>UI Events</a>
  <br>Latest publication: <a href='https://www.w3.org/TR/2016/WD-uievents-20160804/'>04 August 
@@ -711,8 +711,8 @@ href='https://www.w3.org/TR/2013/WD-uievents-20130725/'>https://www.w3.org/TR/20
 5/</a><br>
 associated <a href='https://lists.w3.org/Archives/Member/member-cfe/2013Jul/0008.html'> Call for 
 Exclusion</a> on 25 July 2013
- ended on 22 December 2013<br>Produced under Working Group Charter: 
- https://www.w3.org/2012/webapps/charter/</dd>
+ ended on 22 December 2013<br>Produced under 
+ <a href="https://www.w3.org/2012/webapps/charter/">Web Applications Working Group charter</a></dd>
 
 <dt id=1180 class='spec'><a href='https://www.w3.org/TR/uievents-code/' rel='versionof'>UI Events 
 KeyboardEvent code Values</a>
@@ -724,8 +724,8 @@ href='https://www.w3.org/TR/2015/WD-uievents-code-20151215/'>https://www.w3.org/
 de-20151215/</a><br>
 associated <a href='https://lists.w3.org/Archives/Member/member-cfe/2014Jun/0005.html'> Call for 
 Exclusion</a> on 12 June 2014
- ended on 09 November 2014<br>Produced under Working Group Charter: 
- https://www.w3.org/2014/06/webapps-charter.html</dd>
+ ended on 09 November 2014<br>Produced under 
+ <a href="https://www.w3.org/2014/06/webapps-charter.html">Web Applications Working Group charter</a></dd>
 
 <dt id=1181 class='spec'><a href='https://www.w3.org/TR/uievents-key/' rel='versionof'>UI Events 
 KeyboardEvent key Values</a>
@@ -737,8 +737,8 @@ href='https://www.w3.org/TR/2015/WD-uievents-key-20151215/'>https://www.w3.org/T
 -20151215/</a><br>
 associated <a href='https://www.w3.org/2004/01/pp-impl/42538/admin'> Call for Exclusion</a> on 12 
 June 2014
- ended on 09 November 2014<br>Produced under Working Group Charter:  
- https://www.w3.org/2014/06/webapps-charter.html</dd>
+ ended on 09 November 2014<br>Produced under  
+ <a href="https://www.w3.org/2014/06/webapps-charter.html">Web Applications Working Group charter</a></dd>
 
 <dt id=551 class='spec'><a href='https://www.w3.org/TR/clipboard-apis/' rel='versionof'>Clipboard 
 API and events</a>
@@ -750,8 +750,8 @@ href='https://www.w3.org/TR/2015/WD-clipboard-apis-20151215/'>https://www.w3.org
 apis-20151215/</a><br>
 associated <a href='https://lists.w3.org/Archives/Member/member-webapi/2006Nov/0009.html'> Call for 
 Exclusion</a> on 16 November 2006
- ended on 14 April 2007<br>Produced under Working Group Charter: 
- https://www.w3.org/2006/webapi/admin/charter</dd>
+ ended on 14 April 2007<br>Produced under 
+ <a href="https://www.w3.org/2006/webapi/admin/charter">Web API Working Group charter</a></dd>
 
 <dt id=1195 class='spec'><a href='https://www.w3.org/TR/selection-api/' rel='versionof'>Selection 
 API</a>
@@ -763,8 +763,8 @@ href='https://www.w3.org/TR/2015/WD-selection-api-20151124/'>https://www.w3.org/
 pi-20151124/</a><br>
 associated <a href='https://lists.w3.org/Archives/Member/member-cfe/2014Oct/0002.html'> Call for 
 Exclusion</a> on 07 October 2014
- ended on 06 March 2015<br>Produced under Working Group Charter: 
- https://www.w3.org/2014/06/webapps-charter.html</dd>
+ ended on 06 March 2015<br>Produced under 
+ <a href="https://www.w3.org/2014/06/webapps-charter.html">Web Applications Working Group charter</a></dd>
 
 <dt id=1323 class='spec'><a href='https://www.w3.org/TR/input-events-1/' rel='versionof'>Input 
 Events Level 1</a>
@@ -776,8 +776,8 @@ href='https://www.w3.org/TR/2016/WD-input-events-20160830/'>https://www.w3.org/T
 ts-20160830/</a><br>
 associated <a href='https://lists.w3.org/Archives/Member/member-cfe/2016Aug/0006.html'> Call for 
 Exclusion</a> on 30 August 2016
- ended on 27 January 2017<br>Produced under Working Group Charter: 
- https://www.w3.org/2015/10/webplatform-charter.html</dd>
+ ended on 27 January 2017<br>Produced under 
+ <a href="https://www.w3.org/2015/10/webplatform-charter.html">Web Platform Working Group charter</a></dd>
 
 <dt id=751 class='spec'><a href='https://www.w3.org/TR/FileAPI/' rel='versionof'>File API</a>
  <br>Latest publication: <a href='https://www.w3.org/TR/2015/WD-FileAPI-20150421/'>21 April 
@@ -796,8 +796,8 @@ href='https://www.w3.org/TR/2015/WD-gamepad-20151215/'>https://www.w3.org/TR/201
 </a><br>
 associated <a href='https://lists.w3.org/Archives/Member/member-cfe/2012May/0010.html'> Call for 
 Exclusion</a> on 29 May 2012
- ended on 26 October 2012<br>Produced under Working Group Charter: 
- https://www.w3.org/2010/webapps/charter/</dd>
+ ended on 26 October 2012<br>Produced under 
+ <a href="https://www.w3.org/2010/webapps/charter/">Web Applications Working Group charter</a></dd>
 
 <dt id=981 class='spec'><a href='https://www.w3.org/TR/html51/' rel='versionof'>HTML 5.1</a>
  <br>Latest publication: <a href='https://www.w3.org/TR/2016/REC-html51-20161101/'>01 November 
@@ -808,8 +808,8 @@ href='https://www.w3.org/TR/2016/PR-html51-20160915/'>https://www.w3.org/TR/2016
 </a><br>
 associated <a href='https://lists.w3.org/Archives/Member/member-cfe/2016Jun/0002.html'> Call for 
 Exclusion</a> on 21 June 2016
- ended on 20 August 2016<br>Produced under Working Group Charter: 
- https://www.w3.org/2015/10/webplatform-charter.html</dd>
+ ended on 20 August 2016<br>Produced under 
+ <a href="https://www.w3.org/2015/10/webplatform-charter.html">Web Platform Working Group charter</a></dd>
 
 <dt id=1320 class='spec'><a href='https://www.w3.org/TR/html52/' rel='versionof'>HTML 5.2</a>
  <br>Latest publication: <a href='https://www.w3.org/TR/2017/WD-html52-20170509/'>09 May 
@@ -820,8 +820,8 @@ href='https://www.w3.org/TR/2016/WD-html52-20160818/'>https://www.w3.org/TR/2016
 </a><br>
 associated <a href='https://lists.w3.org/Archives/Member/member-cfe/2016Aug/0003.html'> Call for 
 Exclusion</a> on 18 August 2016
- ended on 15 January 2017<br>Produced under Working Group Charter: 
- https://www.w3.org/2015/10/webplatform-charter.html</dd>
+ ended on 15 January 2017<br>Produced under 
+ <a href="https://www.w3.org/2015/10/webplatform-charter.html">Web Platform Working Group charter</a></dd>
 
 <dt id=1228 class='spec'><a href='https://www.w3.org/TR/html-aam-1.0/' rel='versionof'>HTML 
 Accessibility API Mappings 1.0</a>
@@ -833,8 +833,8 @@ href='https://www.w3.org/TR/2015/WD-html-aam-1.0-20150407/'>https://www.w3.org/T
 -20150407/</a><br>
 associated <a href='https://lists.w3.org/Archives/Member/member-cfe/2015Apr/0000.html'> Call for 
 Exclusion</a> on 09 April 2015
- ended on 04 September 2015<br>Produced under Working Group Charter: 
- https://www.w3.org/WAI/PF/charter201006</dd>
+ ended on 04 September 2015<br>Produced under 
+ <a href="https://www.w3.org/WAI/PF/charter201006">WAI PF Working Group charter</a></dd>
 
 <dt id=1233 class='spec'><a href='https://www.w3.org/TR/html-aria/' rel='versionof'>ARIA in HTML</a>
  <br />Also developed by Web Platform Working Group.Web Platform Working Group.<br>Latest 
@@ -845,8 +845,8 @@ href='https://www.w3.org/TR/2015/WD-html-aria-20150414/'>https://www.w3.org/TR/2
 414/</a><br>
 associated <a href='https://lists.w3.org/Archives/Member/member-cfe/2015Apr/0005.html'> Call for 
 Exclusion</a> on 14 April 2015
- ended on 11 September 2015<br>Produced under Working Group Charter: 
- https://www.w3.org/2013/09/html-charter</dd>
+ ended on 11 September 2015<br>Produced under 
+ <a href="https://www.w3.org/2013/09/html-charter">HTML Working Group charter</a></dd>
 
 <dt id=844 class='spec'><a href='https://www.w3.org/TR/microdata/' rel='versionof'>HTML 
 Microdata</a>
@@ -859,7 +859,7 @@ href='https://www.w3.org/TR/2017/WD-microdata-20170504/'>https://www.w3.org/TR/2
 associated <a href='https://lists.w3.org/Archives/Member/member-cfe/2017May/0001.html'> Call for 
 Exclusion</a> on 04 May 2017
 <br><i>Exclusion opportunity will end on 30 September 2017</i><br>Produced under Working Group 
-Charter: https://www.w3.org/2016/11/webplatform-charter.html</dd>
+Charter: <a href="https://www.w3.org/2016/11/webplatform-charter.html">Web Platform Working Group charter</a></dd>
 
 <dt id=1138 class='spec'><a href='https://www.w3.org/TR/appmanifest/' rel='versionof'>Web App 
 Manifest</a>
@@ -871,8 +871,8 @@ href='https://www.w3.org/TR/2015/WD-appmanifest-20151124/'>https://www.w3.org/TR
 0151124/</a><br>
 associated <a href='https://lists.w3.org/Archives/Member/member-cfe/2013Dec/0004.html'> Call for 
 Exclusion</a> on 17 December 2013
- ended on 16 May 2014<br>Produced under Working Group Charter: 
- https://www.w3.org/2012/webapps/charter/</dd>
+ ended on 16 May 2014<br>Produced under 
+ <a href="https://www.w3.org/2012/webapps/charter/">Web Applications Working Group charter</a></dd>
 
 <dt id=792 class='spec'><a href='https://www.w3.org/TR/websockets/' rel='versionof'>The WebSocket 
 API</a>
@@ -884,8 +884,8 @@ href='https://www.w3.org/TR/2012/WD-websockets-20120809/'>https://www.w3.org/TR/
 20809/</a><br>
 associated <a href='https://lists.w3.org/Archives/Member/member-cfe/2012Aug/0005.html'> Call for 
 Exclusion</a> on 09 August 2012
- ended on 08 October 2012<br>Produced under Working Group Charter: 
- https://www.w3.org/2012/webapps/charter/</dd>
+ ended on 08 October 2012<br>Produced under 
+ <a href="https://www.w3.org/2012/webapps/charter/">Web Applications Working Group charter</a></dd>
 
 <dt id=1345 class='spec'><a href='https://www.w3.org/TR/pointerlock-2/' rel='versionof'>Pointer Lock 
 2.0</a>
@@ -897,8 +897,8 @@ href='https://www.w3.org/TR/2016/WD-pointerlock-2-20161122/'>https://www.w3.org/
 ck-2-20161122/</a><br>
 associated <a href='https://lists.w3.org/Archives/Member/member-cfe/2016Nov/0010.html'> Call for 
 Exclusion</a> on 22 November 2016
- ended on 21 April 2017<br>Produced under Working Group Charter: 
- https://www.w3.org/2016/11/webplatform-charter.html</dd>
+ ended on 21 April 2017<br>Produced under 
+ <a href="https://www.w3.org/2016/11/webplatform-charter.html">Web Platform Working Group charter</a></dd>
 
 <dt id=1000 class='spec'><a href='https://www.w3.org/TR/push-api/' rel='versionof'>Push API</a>
  <br>Latest publication: <a href='https://www.w3.org/TR/2017/WD-push-api-20170508/'>08 May 
@@ -909,8 +909,8 @@ href='https://www.w3.org/TR/2015/WD-push-api-20151215/'>https://www.w3.org/TR/20
 5/</a><br>
 associated <a href='https://lists.w3.org/Archives/Member/member-webapps/2012OctDec/0007.html'> Call 
 for Exclusion</a> on 18 October 2012
- ended on 17 March 2013<br>Produced under Working Group Charter: 
- https://www.w3.org/2012/webapps/charter/</dd>
+ ended on 17 March 2013<br>Produced under 
+ <a href="https://www.w3.org/2012/webapps/charter/">Web Applications Working Group charter</a></dd>
 
 <dt id=1003 class='spec'><a href='https://www.w3.org/TR/screen-orientation/' rel='versionof'>The 
 Screen Orientation API</a>
@@ -922,8 +922,8 @@ href='https://www.w3.org/TR/2015/WD-screen-orientation-20151215/'>https://www.w3
 -orientation-20151215/</a><br>
 associated <a href='https://lists.w3.org/Archives/Member/member-webapps/2012AprJun/0003.html'> Call 
 for Exclusion</a> on 22 May 2012
- ended on 19 October 2012<br>Produced under Working Group Charter: 
- https://www.w3.org/2010/webapps/charter/</dd>
+ ended on 19 October 2012<br>Produced under 
+ <a href="https://www.w3.org/2010/webapps/charter/">Web Applications Working Group charter</a></dd>
 
 <dt id=1038 class='spec'><a href='https://www.w3.org/TR/custom-elements/' rel='versionof'>Custom 
 Elements</a>
@@ -935,8 +935,8 @@ href='https://www.w3.org/TR/2016/WD-custom-elements-20160119/'>https://www.w3.or
 ements-20160119/</a><br>
 associated <a href='https://lists.w3.org/Archives/Member/member-cfe/2013Oct/0008.html'> Call for 
 Exclusion</a> on 24 October 2013
- ended on 23 December 2013<br>Produced under Working Group Charter: 
- https://www.w3.org/2012/webapps/charter/</dd>
+ ended on 23 December 2013<br>Produced under 
+ <a href="https://www.w3.org/2012/webapps/charter/">Web Applications Working Group charter</a></dd>
 
 <dt id=1004 class='spec'><a href='https://www.w3.org/TR/shadow-dom/' rel='versionof'>Shadow DOM</a>
  <br>Latest publication: <a href='https://www.w3.org/TR/2017/WD-shadow-dom-20170213/'>13 February 
@@ -947,8 +947,8 @@ href='https://www.w3.org/TR/2015/WD-shadow-dom-20151215/'>https://www.w3.org/TR/
 51215/</a><br>
 associated <a href='https://lists.w3.org/Archives/Member/member-webapps/2012AprJun/0003.html'> Call 
 for Exclusion</a> on 22 May 2012
- ended on 19 October 2012<br>Produced under Working Group Charter: 
- https://www.w3.org/2010/webapps/charter/</dd>
+ ended on 19 October 2012<br>Produced under 
+ <a href="https://www.w3.org/2010/webapps/charter/">Web Applications Working Group charter</a></dd>
 
 <dt id=797 class='spec'><a href='https://www.w3.org/TR/workers/' rel='versionof'>Web Workers</a>
  <br>Latest publication: <a href='https://www.w3.org/TR/2015/WD-workers-20150924/'>24 September 
@@ -959,8 +959,8 @@ href='https://www.w3.org/TR/2015/WD-workers-20150924/'>https://www.w3.org/TR/201
 </a><br>
 associated <a href='https://lists.w3.org/Archives/Member/member-webapps/2012JanMar/0007.html'> Call 
 for Exclusion</a> on 13 March 2012
- ended on 12 May 2012<br>Produced under Working Group Charter: 
- https://www.w3.org/2010/webapps/charter/</dd>
+ ended on 12 May 2012<br>Produced under 
+ <a href="https://www.w3.org/2010/webapps/charter/">Web Applications Working Group charter</a></dd>
 
 </dl>
      </section>
@@ -969,7 +969,7 @@ for Exclusion</a> on 13 March 2012
         <h3 id="changes-from-wp1">Changes from the previous charter</h3>
         <p>The major changes from the <a 
         href="https://www.w3.org/2016/11/webplatform-charter.html">second Web platform Working Group
-            charter</a> include:</p>
+            Working Group charter</a> include:</p>
         <p> </p>
         <dl>
           <dt>New deliverables:</dt>

--- a/webplat-wg.html
+++ b/webplat-wg.html
@@ -72,7 +72,7 @@
         <li><a href="#licensing">Licensing</a></li>
         <li><a href="#about">About this Charter</a></li>
       </ul>
-      <p><a href="https://www.w3.org/"><img src="http://www.w3.org/Icons/w3c_home" alt="W3C" 
+      <p><a href="https://www.w3.org/"><img src="https://www.w3.org/Icons/w3c_home" alt="W3C" 
       height="48" width="72"></a> </p>
       <h1 id="title">[PROPOSED]<br>
         Web Platform Working Group Charter</h1>
@@ -240,7 +240,7 @@
               <dd>Expose common clipboard operations such as cut, copy and paste to Web 
               Applications.</dd>
               <dt id="selection"><a href="#1195">Selection 
-              API</a> - <a href="http://w3c.github.io/selection-api/">Editors' Copy</a></dt>
+              API</a> - <a href="https://w3c.github.io/selection-api/">Editors' Copy</a></dt>
               <dd>APIs for selection, which allows users and authors to select a portion of a 
               document or specify a point of interest for
                 copy, paste, and other editing operations.</dd>
@@ -270,7 +270,7 @@
           <dt id="gamepad"><a href="#979">Gamepad</a> - <a 
           href="https://w3c.github.io/gamepad/gamepad.html">Editors' Copy</a></dt>
           <dd>APIs that allow Web applications to directly act on gamepad data.</dd>
-          <dt><a href="http://www.w3.org/TR/html/">HTML</a></dt>
+          <dt><a href="https://www.w3.org/TR/html/">HTML</a></dt>
           <dd>Specifications to define the HTML language, HTML-specific APIs for interacting with 
           in-memory representations of resources
             that use the HTML language, and to define normative requirements for browsers and other 
@@ -281,13 +281,13 @@
               <dd>The core language of the World Wide Web: the Hypertext Markup Language (HTML). The 
               HTML specification should be
                 progressively modularized into separate documents or <a 
-                href="http://www.w3.org/TR/html5/introduction.html#extensibility">extension
+                href="https://www.w3.org/TR/html5/introduction.html#extensibility">extension
                   specifications</a>. Note that many other Working Groups define extensions to HTML. 
                   These should be referenced from the <a
                   href="https://w3c.github.io/html-extensions/">HTML Extension</a> 
                   specification</dd>
               <dt><a href="#1228">HTML Accessibility API 
-              Mappings 1.0</a> - <a href="http://w3c.github.io/aria/html-aam/html-aam.html">Editors' 
+              Mappings 1.0</a> - <a href="https://w3c.github.io/aria/html-aam/html-aam.html">Editors' 
               Copy</a></dt>
               <dd>How to map HTML elements and attributes to platform accessibility APIs.</dd>
               <dt><a href="#1233">ARIA in HTML</a></dt>
@@ -299,7 +299,7 @@
             </dl>
           </dd>
           <dt id="manifest"><a href="#1138">Manifest for Web 
-          applications</a> - <a href="http://w3c.github.io/manifest/">Editors' Copy</a></dt>
+          applications</a> - <a href="https://w3c.github.io/manifest/">Editors' Copy</a></dt>
           <dd>A JSON-based manifest, to provide metadata about a web application.</dd>
           <dt id="network">Network</dt>
           <dd>Specifications that allow network communications:
@@ -338,7 +338,7 @@
                 functional encapsulation within the DOM.</dd>
             </dl>
           </dd>
-          <dt id="webidl"><a href="http://heycam.github.io/webidl/">Web Interface Definition 
+          <dt id="webidl"><a href="https://heycam.github.io/webidl/">Web Interface Definition 
           Language (Web IDL)</a></dt>
           <dd>Language bindings and types for Web interface descriptions.</dd>
           <dt id="web-workers"><a title="Web Workers" href="#797">Web 
@@ -359,15 +359,15 @@
           <dd>An API for the 2D Context of the HTML canvas element.</dd>
           <dt><a href="https://w3c.github.io/ime-api/">Input Method (IME) API</a></dt>
           <dd>An API that provides access to a (native) input method editor.</dd>
-          <dt id="file-system-2"><a href="http://w3c.github.io/filesystem-api/">FileSystem 
+          <dt id="file-system-2"><a href="https://w3c.github.io/filesystem-api/">FileSystem 
           API</a></dt>
           <dd>A local sandboxed file system API exposed only to Web Applications.</dd>
-          <dt id="packaging"><a href="http://w3ctag.github.io/packaging-on-the-web/">Packaging on 
+          <dt id="packaging"><a href="https://w3ctag.github.io/packaging-on-the-web/">Packaging on 
           the Web</a></dt>
           <dd>Defines an approach for creating packages of files for use on the web.</dd>
           <dt><a href="https://w3c.github.io/quota-api/">Quota Management API</a></dt>
           <dd>An API for managing the amount of storage space (short- or long-term) available.</dd>
-          <dt><a href="http://w3c.github.io/webcomponents/spec/imports/">HTML Imports</a></dt>
+          <dt><a href="https://w3c.github.io/webcomponents/spec/imports/">HTML Imports</a></dt>
           <dd>A way to include and reuse HTML documents in another HTML document.</dd>
         </dl>
         <p><em>Note:</em> The list of specifications above were Recommendation Track documents in 
@@ -394,7 +394,7 @@
         <p>For current information on the list of deliverables and their status see the Web Platform 
         WG <a href="https://www.w3.org/WebPlatform/WG/PubStatus">Publication
             Status</a> page.</p>
-        <h4 id="maintenance">2.1.1. Specification Maintenance</h4>
+        <h4 id="maintenance">Specification Maintenance</h4>
         <p>The working group will maintain errata and publish revisions, as necessary, for the 
         following W3C Recommendations:</p>
         <ul>
@@ -650,7 +650,7 @@
       <section class="licensing">
         <h2 id="licensing">Licensing</h2>
         <p>This Working Group will use the <a 
-        href="http://www.w3.org/Consortium/Legal/copyright-software">W3C Software and Document
+        href="https://www.w3.org/Consortium/Legal/copyright-software">W3C Software and Document
             license</a> for all its deliverables.</p>
       </section>
       <section class="patent">
@@ -675,7 +675,7 @@
         associated <a href="https://lists.w3.org/Archives/Member/member-cfe/2016Aug/0003.html">Call 
         for Exclusion</a> on 18 August 2016 ended on 15 January 2017
         <br>Produced under Working Group Charter: 
-        http://www.w3.org/2015/10/webplatform-charter.html</dd>
+        https://www.w3.org/2015/10/webplatform-charter.html</dd>
 
 <dt id=1357 class='spec'><a href='https://www.w3.org/TR/dom41/' rel='versionof'>W3C DOM 4.1</a>
  <br>Latest publication: <a href='https://www.w3.org/TR/2017/WD-dom41-20170420/'>20 April 
@@ -687,32 +687,32 @@ a><br>
 associated <a href='https://lists.w3.org/Archives/Member/member-cfe/2017Mar/0002.html'> Call for 
 Exclusion</a> on 22 March 2017
 <br><i>Exclusion opportunity will end on 18 August 2017</i><br>Produced under Working Group Charter: 
-http://www.w3.org/2016/11/webplatform-charter.html</dd>
+https://www.w3.org/2016/11/webplatform-charter.html</dd>
 
-<dt id=952 class='spec'><a href='http://www.w3.org/TR/DOM-Parsing/' rel='versionof'>DOM Parsing and 
+<dt id=952 class='spec'><a href='https://www.w3.org/TR/DOM-Parsing/' rel='versionof'>DOM Parsing and 
 Serialization</a>
- <br>Latest publication: <a href='http://www.w3.org/TR/2016/WD-DOM-Parsing-20160517/'>17 May 
+ <br>Latest publication: <a href='https://www.w3.org/TR/2016/WD-DOM-Parsing-20160517/'>17 May 
  2016</a></dt>
 <dd>Reference Draft:
 <a 
-href='http://www.w3.org/TR/2016/WD-DOM-Parsing-20160517/'>http://www.w3.org/TR/2016/WD-DOM-Parsing-2
+href='https://www.w3.org/TR/2016/WD-DOM-Parsing-20160517/'>https://www.w3.org/TR/2016/WD-DOM-Parsing-2
 0160517/</a><br>
 associated <a href='https://lists.w3.org/Archives/Member/member-cfe/2014May/0005.html'> Call for 
 Exclusion</a> on 01 May 2014
  ended on 30 June 2014<br>Produced under Working Group Charter: 
- http://www.w3.org/2012/webapps/charter/</dd>
+ https://www.w3.org/2012/webapps/charter/</dd>
 
 <dt id=194 class='spec'><a href='https://www.w3.org/TR/uievents/' rel='versionof'>UI Events</a>
  <br>Latest publication: <a href='https://www.w3.org/TR/2016/WD-uievents-20160804/'>04 August 
  2016</a></dt>
 <dd>Reference Draft:
 <a 
-href='http://www.w3.org/TR/2013/WD-uievents-20130725/'>http://www.w3.org/TR/2013/WD-uievents-2013072
+href='https://www.w3.org/TR/2013/WD-uievents-20130725/'>https://www.w3.org/TR/2013/WD-uievents-2013072
 5/</a><br>
 associated <a href='https://lists.w3.org/Archives/Member/member-cfe/2013Jul/0008.html'> Call for 
 Exclusion</a> on 25 July 2013
  ended on 22 December 2013<br>Produced under Working Group Charter: 
- http://www.w3.org/2012/webapps/charter/</dd>
+ https://www.w3.org/2012/webapps/charter/</dd>
 
 <dt id=1180 class='spec'><a href='https://www.w3.org/TR/uievents-code/' rel='versionof'>UI Events 
 KeyboardEvent code Values</a>
@@ -720,12 +720,12 @@ KeyboardEvent code Values</a>
  2016</a></dt>
 <dd>Reference Draft:
 <a 
-href='http://www.w3.org/TR/2015/WD-uievents-code-20151215/'>http://www.w3.org/TR/2015/WD-uievents-co
+href='https://www.w3.org/TR/2015/WD-uievents-code-20151215/'>https://www.w3.org/TR/2015/WD-uievents-co
 de-20151215/</a><br>
 associated <a href='https://lists.w3.org/Archives/Member/member-cfe/2014Jun/0005.html'> Call for 
 Exclusion</a> on 12 June 2014
  ended on 09 November 2014<br>Produced under Working Group Charter: 
- http://www.w3.org/2014/06/webapps-charter.html</dd>
+ https://www.w3.org/2014/06/webapps-charter.html</dd>
 
 <dt id=1181 class='spec'><a href='https://www.w3.org/TR/uievents-key/' rel='versionof'>UI Events 
 KeyboardEvent key Values</a>
@@ -733,12 +733,12 @@ KeyboardEvent key Values</a>
  2016</a></dt>
 <dd>Reference Draft: 
 <a 
-href='http://www.w3.org/TR/2015/WD-uievents-key-20151215/'>http://www.w3.org/TR/2015/WD-uievents-key
+href='https://www.w3.org/TR/2015/WD-uievents-key-20151215/'>https://www.w3.org/TR/2015/WD-uievents-key
 -20151215/</a><br>
 associated <a href='https://www.w3.org/2004/01/pp-impl/42538/admin'> Call for Exclusion</a> on 12 
 June 2014
  ended on 09 November 2014<br>Produced under Working Group Charter:  
- http://www.w3.org/2014/06/webapps-charter.html</dd>
+ https://www.w3.org/2014/06/webapps-charter.html</dd>
 
 <dt id=551 class='spec'><a href='https://www.w3.org/TR/clipboard-apis/' rel='versionof'>Clipboard 
 API and events</a>
@@ -746,12 +746,12 @@ API and events</a>
  December 2016</a></dt>
 <dd>Reference Draft: 
 <a 
-href='http://www.w3.org/TR/2015/WD-clipboard-apis-20151215/'>http://www.w3.org/TR/2015/WD-clipboard-
+href='https://www.w3.org/TR/2015/WD-clipboard-apis-20151215/'>https://www.w3.org/TR/2015/WD-clipboard-
 apis-20151215/</a><br>
-associated <a href='http://lists.w3.org/Archives/Member/member-webapi/2006Nov/0009.html'> Call for 
+associated <a href='https://lists.w3.org/Archives/Member/member-webapi/2006Nov/0009.html'> Call for 
 Exclusion</a> on 16 November 2006
  ended on 14 April 2007<br>Produced under Working Group Charter: 
- http://www.w3.org/2006/webapi/admin/charter</dd>
+ https://www.w3.org/2006/webapi/admin/charter</dd>
 
 <dt id=1195 class='spec'><a href='https://www.w3.org/TR/selection-api/' rel='versionof'>Selection 
 API</a>
@@ -759,12 +759,12 @@ API</a>
  2017</a></dt>
 <dd>Reference Draft: 
 <a 
-href='http://www.w3.org/TR/2015/WD-selection-api-20151124/'>http://www.w3.org/TR/2015/WD-selection-a
+href='https://www.w3.org/TR/2015/WD-selection-api-20151124/'>https://www.w3.org/TR/2015/WD-selection-a
 pi-20151124/</a><br>
 associated <a href='https://lists.w3.org/Archives/Member/member-cfe/2014Oct/0002.html'> Call for 
 Exclusion</a> on 07 October 2014
  ended on 06 March 2015<br>Produced under Working Group Charter: 
- http://www.w3.org/2014/06/webapps-charter.html</dd>
+ https://www.w3.org/2014/06/webapps-charter.html</dd>
 
 <dt id=1323 class='spec'><a href='https://www.w3.org/TR/input-events-1/' rel='versionof'>Input 
 Events Level 1</a>
@@ -777,14 +777,14 @@ ts-20160830/</a><br>
 associated <a href='https://lists.w3.org/Archives/Member/member-cfe/2016Aug/0006.html'> Call for 
 Exclusion</a> on 30 August 2016
  ended on 27 January 2017<br>Produced under Working Group Charter: 
- http://www.w3.org/2015/10/webplatform-charter.html</dd>
+ https://www.w3.org/2015/10/webplatform-charter.html</dd>
 
-<dt id=751 class='spec'><a href='http://www.w3.org/TR/FileAPI/' rel='versionof'>File API</a>
- <br>Latest publication: <a href='http://www.w3.org/TR/2015/WD-FileAPI-20150421/'>21 April 
+<dt id=751 class='spec'><a href='https://www.w3.org/TR/FileAPI/' rel='versionof'>File API</a>
+ <br>Latest publication: <a href='https://www.w3.org/TR/2015/WD-FileAPI-20150421/'>21 April 
  2015</a></dt>
 <dd>Reference Draft: 
 <a 
-href='http://www.w3.org/TR/2015/WD-FileAPI-20150421/'>http://www.w3.org/TR/2015/WD-FileAPI-20150421/
+href='https://www.w3.org/TR/2015/WD-FileAPI-20150421/'>https://www.w3.org/TR/2015/WD-FileAPI-20150421/
 </a><br>
 
 <dt id=979 class='spec'><a href='https://www.w3.org/TR/gamepad/' rel='versionof'>Gamepad</a>
@@ -792,12 +792,12 @@ href='http://www.w3.org/TR/2015/WD-FileAPI-20150421/'>http://www.w3.org/TR/2015/
  2017</a></dt>
 <dd>Reference Draft: 
 <a 
-href='http://www.w3.org/TR/2015/WD-gamepad-20151215/'>http://www.w3.org/TR/2015/WD-gamepad-20151215/
+href='https://www.w3.org/TR/2015/WD-gamepad-20151215/'>https://www.w3.org/TR/2015/WD-gamepad-20151215/
 </a><br>
 associated <a href='https://lists.w3.org/Archives/Member/member-cfe/2012May/0010.html'> Call for 
 Exclusion</a> on 29 May 2012
  ended on 26 October 2012<br>Produced under Working Group Charter: 
- http://www.w3.org/2010/webapps/charter/</dd>
+ https://www.w3.org/2010/webapps/charter/</dd>
 
 <dt id=981 class='spec'><a href='https://www.w3.org/TR/html51/' rel='versionof'>HTML 5.1</a>
  <br>Latest publication: <a href='https://www.w3.org/TR/2016/REC-html51-20161101/'>01 November 
@@ -809,7 +809,7 @@ href='https://www.w3.org/TR/2016/PR-html51-20160915/'>https://www.w3.org/TR/2016
 associated <a href='https://lists.w3.org/Archives/Member/member-cfe/2016Jun/0002.html'> Call for 
 Exclusion</a> on 21 June 2016
  ended on 20 August 2016<br>Produced under Working Group Charter: 
- http://www.w3.org/2015/10/webplatform-charter.html</dd>
+ https://www.w3.org/2015/10/webplatform-charter.html</dd>
 
 <dt id=1320 class='spec'><a href='https://www.w3.org/TR/html52/' rel='versionof'>HTML 5.2</a>
  <br>Latest publication: <a href='https://www.w3.org/TR/2017/WD-html52-20170509/'>09 May 
@@ -821,7 +821,7 @@ href='https://www.w3.org/TR/2016/WD-html52-20160818/'>https://www.w3.org/TR/2016
 associated <a href='https://lists.w3.org/Archives/Member/member-cfe/2016Aug/0003.html'> Call for 
 Exclusion</a> on 18 August 2016
  ended on 15 January 2017<br>Produced under Working Group Charter: 
- http://www.w3.org/2015/10/webplatform-charter.html</dd>
+ https://www.w3.org/2015/10/webplatform-charter.html</dd>
 
 <dt id=1228 class='spec'><a href='https://www.w3.org/TR/html-aam-1.0/' rel='versionof'>HTML 
 Accessibility API Mappings 1.0</a>
@@ -829,19 +829,19 @@ Accessibility API Mappings 1.0</a>
  2017</a></dt>
 <dd>Reference Draft: 
 <a 
-href='http://www.w3.org/TR/2015/WD-html-aam-1.0-20150407/'>http://www.w3.org/TR/2015/WD-html-aam-1.0
+href='https://www.w3.org/TR/2015/WD-html-aam-1.0-20150407/'>https://www.w3.org/TR/2015/WD-html-aam-1.0
 -20150407/</a><br>
 associated <a href='https://lists.w3.org/Archives/Member/member-cfe/2015Apr/0000.html'> Call for 
 Exclusion</a> on 09 April 2015
  ended on 04 September 2015<br>Produced under Working Group Charter: 
- http://www.w3.org/WAI/PF/charter201006</dd>
+ https://www.w3.org/WAI/PF/charter201006</dd>
 
 <dt id=1233 class='spec'><a href='https://www.w3.org/TR/html-aria/' rel='versionof'>ARIA in HTML</a>
  <br />Also developed by Web Platform Working Group.Web Platform Working Group.<br>Latest 
  publication: <a href='https://www.w3.org/TR/2017/WD-html-aria-20170323/'>23 March 2017</a></dt>
 <dd>Reference Draft: 
 <a 
-href='http://www.w3.org/TR/2015/WD-html-aria-20150414/'>http://www.w3.org/TR/2015/WD-html-aria-20150
+href='https://www.w3.org/TR/2015/WD-html-aria-20150414/'>https://www.w3.org/TR/2015/WD-html-aria-20150
 414/</a><br>
 associated <a href='https://lists.w3.org/Archives/Member/member-cfe/2015Apr/0005.html'> Call for 
 Exclusion</a> on 14 April 2015
@@ -859,7 +859,7 @@ href='https://www.w3.org/TR/2017/WD-microdata-20170504/'>https://www.w3.org/TR/2
 associated <a href='https://lists.w3.org/Archives/Member/member-cfe/2017May/0001.html'> Call for 
 Exclusion</a> on 04 May 2017
 <br><i>Exclusion opportunity will end on 30 September 2017</i><br>Produced under Working Group 
-Charter: http://www.w3.org/2016/11/webplatform-charter.html</dd>
+Charter: https://www.w3.org/2016/11/webplatform-charter.html</dd>
 
 <dt id=1138 class='spec'><a href='https://www.w3.org/TR/appmanifest/' rel='versionof'>Web App 
 Manifest</a>
@@ -867,25 +867,25 @@ Manifest</a>
  2017</a></dt>
 <dd>Reference Draft: 
 <a 
-href='http://www.w3.org/TR/2015/WD-appmanifest-20151124/'>http://www.w3.org/TR/2015/WD-appmanifest-2
+href='https://www.w3.org/TR/2015/WD-appmanifest-20151124/'>https://www.w3.org/TR/2015/WD-appmanifest-2
 0151124/</a><br>
 associated <a href='https://lists.w3.org/Archives/Member/member-cfe/2013Dec/0004.html'> Call for 
 Exclusion</a> on 17 December 2013
  ended on 16 May 2014<br>Produced under Working Group Charter: 
- http://www.w3.org/2012/webapps/charter/</dd>
+ https://www.w3.org/2012/webapps/charter/</dd>
 
-<dt id=792 class='spec'><a href='http://www.w3.org/TR/websockets/' rel='versionof'>The WebSocket 
+<dt id=792 class='spec'><a href='https://www.w3.org/TR/websockets/' rel='versionof'>The WebSocket 
 API</a>
- <br>Latest publication: <a href='http://www.w3.org/TR/2012/CR-websockets-20120920/'>20 September 
+ <br>Latest publication: <a href='https://www.w3.org/TR/2012/CR-websockets-20120920/'>20 September 
  2012</a></dt>
 <dd>Reference Draft: 
 <a 
-href='http://www.w3.org/TR/2012/WD-websockets-20120809/'>http://www.w3.org/TR/2012/WD-websockets-201
+href='https://www.w3.org/TR/2012/WD-websockets-20120809/'>https://www.w3.org/TR/2012/WD-websockets-201
 20809/</a><br>
 associated <a href='https://lists.w3.org/Archives/Member/member-cfe/2012Aug/0005.html'> Call for 
 Exclusion</a> on 09 August 2012
  ended on 08 October 2012<br>Produced under Working Group Charter: 
- http://www.w3.org/2012/webapps/charter/</dd>
+ https://www.w3.org/2012/webapps/charter/</dd>
 
 <dt id=1345 class='spec'><a href='https://www.w3.org/TR/pointerlock-2/' rel='versionof'>Pointer Lock 
 2.0</a>
@@ -898,19 +898,19 @@ ck-2-20161122/</a><br>
 associated <a href='https://lists.w3.org/Archives/Member/member-cfe/2016Nov/0010.html'> Call for 
 Exclusion</a> on 22 November 2016
  ended on 21 April 2017<br>Produced under Working Group Charter: 
- http://www.w3.org/2016/11/webplatform-charter.html</dd>
+ https://www.w3.org/2016/11/webplatform-charter.html</dd>
 
 <dt id=1000 class='spec'><a href='https://www.w3.org/TR/push-api/' rel='versionof'>Push API</a>
  <br>Latest publication: <a href='https://www.w3.org/TR/2017/WD-push-api-20170508/'>08 May 
  2017</a></dt>
 <dd>Reference Draft: 
 <a 
-href='http://www.w3.org/TR/2015/WD-push-api-20151215/'>http://www.w3.org/TR/2015/WD-push-api-2015121
+href='https://www.w3.org/TR/2015/WD-push-api-20151215/'>https://www.w3.org/TR/2015/WD-push-api-2015121
 5/</a><br>
 associated <a href='https://lists.w3.org/Archives/Member/member-webapps/2012OctDec/0007.html'> Call 
 for Exclusion</a> on 18 October 2012
  ended on 17 March 2013<br>Produced under Working Group Charter: 
- http://www.w3.org/2012/webapps/charter/</dd>
+ https://www.w3.org/2012/webapps/charter/</dd>
 
 <dt id=1003 class='spec'><a href='https://www.w3.org/TR/screen-orientation/' rel='versionof'>The 
 Screen Orientation API</a>
@@ -918,12 +918,12 @@ Screen Orientation API</a>
  October 2016</a></dt>
 <dd>Reference Draft: 
 <a 
-href='http://www.w3.org/TR/2015/WD-screen-orientation-20151215/'>http://www.w3.org/TR/2015/WD-screen
+href='https://www.w3.org/TR/2015/WD-screen-orientation-20151215/'>https://www.w3.org/TR/2015/WD-screen
 -orientation-20151215/</a><br>
 associated <a href='https://lists.w3.org/Archives/Member/member-webapps/2012AprJun/0003.html'> Call 
 for Exclusion</a> on 22 May 2012
  ended on 19 October 2012<br>Produced under Working Group Charter: 
- http://www.w3.org/2010/webapps/charter/</dd>
+ https://www.w3.org/2010/webapps/charter/</dd>
 
 <dt id=1038 class='spec'><a href='https://www.w3.org/TR/custom-elements/' rel='versionof'>Custom 
 Elements</a>
@@ -931,36 +931,36 @@ Elements</a>
  October 2016</a></dt>
 <dd>Reference Draft: 
 <a 
-href='http://www.w3.org/TR/2016/WD-custom-elements-20160119/'>http://www.w3.org/TR/2016/WD-custom-el
+href='https://www.w3.org/TR/2016/WD-custom-elements-20160119/'>https://www.w3.org/TR/2016/WD-custom-el
 ements-20160119/</a><br>
 associated <a href='https://lists.w3.org/Archives/Member/member-cfe/2013Oct/0008.html'> Call for 
 Exclusion</a> on 24 October 2013
  ended on 23 December 2013<br>Produced under Working Group Charter: 
- http://www.w3.org/2012/webapps/charter/</dd>
+ https://www.w3.org/2012/webapps/charter/</dd>
 
 <dt id=1004 class='spec'><a href='https://www.w3.org/TR/shadow-dom/' rel='versionof'>Shadow DOM</a>
  <br>Latest publication: <a href='https://www.w3.org/TR/2017/WD-shadow-dom-20170213/'>13 February 
  2017</a></dt>
 <dd>Reference Draft: 
 <a 
-href='http://www.w3.org/TR/2015/WD-shadow-dom-20151215/'>http://www.w3.org/TR/2015/WD-shadow-dom-201
+href='https://www.w3.org/TR/2015/WD-shadow-dom-20151215/'>https://www.w3.org/TR/2015/WD-shadow-dom-201
 51215/</a><br>
 associated <a href='https://lists.w3.org/Archives/Member/member-webapps/2012AprJun/0003.html'> Call 
 for Exclusion</a> on 22 May 2012
  ended on 19 October 2012<br>Produced under Working Group Charter: 
- http://www.w3.org/2010/webapps/charter/</dd>
+ https://www.w3.org/2010/webapps/charter/</dd>
 
-<dt id=797 class='spec'><a href='http://www.w3.org/TR/workers/' rel='versionof'>Web Workers</a>
- <br>Latest publication: <a href='http://www.w3.org/TR/2015/WD-workers-20150924/'>24 September 
+<dt id=797 class='spec'><a href='https://www.w3.org/TR/workers/' rel='versionof'>Web Workers</a>
+ <br>Latest publication: <a href='https://www.w3.org/TR/2015/WD-workers-20150924/'>24 September 
  2015</a></dt>
 <dd>Reference Draft: 
 <a 
-href='http://www.w3.org/TR/2015/WD-workers-20150924/'>http://www.w3.org/TR/2015/WD-workers-20150924/
+href='https://www.w3.org/TR/2015/WD-workers-20150924/'>https://www.w3.org/TR/2015/WD-workers-20150924/
 </a><br>
 associated <a href='https://lists.w3.org/Archives/Member/member-webapps/2012JanMar/0007.html'> Call 
 for Exclusion</a> on 13 March 2012
  ended on 12 May 2012<br>Produced under Working Group Charter: 
- http://www.w3.org/2010/webapps/charter/</dd>
+ https://www.w3.org/2010/webapps/charter/</dd>
 
 </dl>
      </section>
@@ -997,10 +997,10 @@ for Exclusion</a> on 13 March 2012
       <p class="copyright"> <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright" 
       rel="Copyright">Copyright</a>© 2017 <a href="https://www.w3.org/"><abbr
             title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup> (<a 
-            href="http://www.csail.mit.edu/"><abbr title="Massachusetts Institute of 
+            href="https://www.csail.mit.edu/"><abbr title="Massachusetts Institute of 
             Technology">MIT</abbr></a>,
-        <a href="http://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and 
-        Mathematics">ERCIM</abbr></a>, <a href="http://www.keio.ac.jp/">Keio</a>,
+        <a href="https://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and 
+        Mathematics">ERCIM</abbr></a>, <a href="https://www.keio.ac.jp/">Keio</a>,
         <a href="http://ev.buaa.edu.cn/">Beihang</a>), All Rights Reserved.</p>
     </section>
   </body>

--- a/webplat-wg.html
+++ b/webplat-wg.html
@@ -501,11 +501,7 @@
           <dt><a href="https://www.w3.org/2001/tag/">Technical Architecture Group</a></dt>
           <dd>The Web Platform WG will ask the Technical Architecture Group to review 
           specifications.</dd>
-          <dt><a href="https://www.w3.org/Mobile/IG/">Web and Mobile Interest Group</a></dt>
-          <dd>This group may provide advice or review to ensure that Web Platform WG deliverables 
-          interact correctly in the context of
-            Mobile applications.</dd>
-          <dt><a href="https://www.w3.org/2011/webtv/">Web and TV Interest Group</a></dt>
+          <dt><a href="https://www.w3.org/2011/webtv/">Media and Entertainment Interest Group</a></dt>
           <dd>This Group may review existing work, as well as the relationship between services on 
           the Web and media services, and identify
             requirements and potential solutions to ensure that the Web will function well with 

--- a/webplat-wg.html
+++ b/webplat-wg.html
@@ -218,7 +218,7 @@
               Observers</a></dt>
               <dd>A specification that gives authors information about the visibility of particular 
               elements</dd>
-              <dt id="ui-events"><a href="#194">UI Events</a> - ><a 
+              <dt id="ui-events"><a href="#194">UI Events</a> - <a
               href="https://w3c.github.io/uievents/">Editors' Copy</a></dt>
               <dd>Events typically implemented by interactive user agents for user interaction such 
               as mouse and keyboard input.</dd>
@@ -247,14 +247,14 @@
               <dt><a href="http://garykac.github.io/staticrange/">Static Range</a></dt>
               <dd>A utility API defining a simple range, for optimized performance</dd>
               <dt><a href="#1323">Input Events</a> - <a 
-              href="https://w3c.github.io/input-events/"></a></dt>
+              href="https://w3c.github.io/input-events/">Editors' Copy</a></dt>
               <dd>A specification defining additions to events for text and related input to allow 
               for the monitoring and manipulation of
                 default browser behavior in the context of text editor applications and other 
                 applications that deal with text input and
                 text formatting.</dd>
               <dt><a 
-              href="https://w3c.github.io/editing/contentEditable.html">contentEditable</a></dt>
+              href="https://w3c.github.io/editing/contentEditable.html">contentEditable</a> - <a href="http://w3c.github.io/editing/contentEditable.html">Editors' Copy</a></dt>
               <dd>A specification defining new values for the <code>contentEditable</code> 
               attribute.</dd>
               <dt><a href="https://w3c.github.io/editing/execCommand.html">execCommand</a></dt>


### PR DESCRIPTION
* Web and TV IG is getting renamed
* Web and Mobile is gone
* Adding a few more editor's copy links in section 3
* In detailed list of deliverables, the charter links should really be href.