### PR TITLE
birds migrate, specs become Recommendation-track

### DIFF
--- a/webplat-wg.html
+++ b/webplat-wg.html
@@ -350,10 +350,8 @@
         </dl>
         <h4>Potential deliverables</h4>
         <p>The following documents have been identified as potential Recommendation Track 
-        deliverables, if there is consensus in the Working Group that they are <a 
-        href="https://wicg.github.io/admin/intent-to-migrate.html">ready to migrate</a>. Documents 
-        not included in this list will require a change to this charter before they are adopted by 
-        the Working Group.</p>
+        deliverables, if there is consensus in the Working Group that they are
+        <a href="https://wicg.github.io/admin/intent-to-migrate.html">ready to become Recommendation-track</a>.</p>
         <dl>
           <dt><a href="https://www.w3.org/TR/2dcontext/">HTML Canvas 2D Context</a></dt>
           <dd>An API for the 2D Context of the HTML canvas element.</dd>
@@ -371,29 +369,23 @@
           <dd>A way to include and reuse HTML documents in another HTML document.</dd>
         </dl>
         <p><em>Note:</em> The list of specifications above were Recommendation Track documents in 
-        the previous charter. They are not
-          statements about incubation success, but more example of the incubation process applied to 
-          the list of deliverables of the
+        the previous charter. They are not statements about incubation success,
+          but examples of the incubation process applied to the list of deliverables in the
           previous charter.</p>
         <p>Each specification should detail any known security implications for implementers, Web 
         authors, and end users.</p>
-        <p>The Web Platform WG will actively seek security, privacy, internationalization and 
-        accessibility review on all its
-          specifications.</p>
+        <p>The Web Platform WG will actively seek security, privacy, internationalization, 
+        accessibility and architectural review on all its specifications.</p>
         <p>If a specification reaches Recommendation status the working group may work on, and 
-        deliver an updated version of the
-          specification under this charter. Specifications may be moved to Recommendation and a 
-          subsequent version begun to facilitate the
-          progress of other work which depends on a stable reference.</p>
+        deliver an updated version of the specification under this charter.
+          Specifications may be moved to Recommendation and a subsequent version begun
+          to facilitate the progress of other work which depends on a stable reference.</p>
         <p>The Working Group will not adopt new proposals until they have matured through the <a 
-        href="https://wicg.io/">Web Platform
-            Incubator Community Group</a> or another similar incubation phase. If the Working Group 
-            decides to add new Recommendation-track
-          deliverables then it will recharter with changes to that new charter limited to just the 
-          changes in deliverables.</p>
+        href="https://wicg.io/">Web Platform Incubator Community Group</a> or a similar incubation phase.
+          If the Working Group decides to add new Recommendation-track deliverables 
+          then it will recharter with changes to change its deliverables.</p>
         <p>For current information on the list of deliverables and their status see the Web Platform 
-        WG <a href="https://www.w3.org/WebPlatform/WG/PubStatus">Publication
-            Status</a> page.</p>
+        WG <a href="https://www.w3.org/WebPlatform/WG/PubStatus">Publication Status</a> page.</p>
         <h4 id="maintenance">Specification Maintenance</h4>
         <p>The working group will maintain errata and publish revisions, as necessary, for the 
         following W3C Recommendations:</p>


### PR DESCRIPTION
fix #158

(And clean up some related redundancy and split links in this section)