### PR TITLE
point to more useful stuff

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,8 @@
     </p>
     <h1>HTML charter</h1>
 
-    <p>This is only a placeholder.</p>
-    <p>See instead <a href="html-plan.html">html-plan</a>.</p>
+    <p>The HTML specification is currently developed by the Web Platform Working Group.</p>
+    <p>See the <a href="https://www.w3.org/2016/11/webplatform-charter.html">Current Web Platform WG charter</a>, and
+     the <a href="webplat-wg.html">editors' draft of the proposed new Web Platform WG charter</p>.</p>
   </body>
 </html>


### PR DESCRIPTION
 https://w3c.github.io/charter-html/ was pointing to [html-plan](html-plan), which is out of date. And that should be updated too.