### PR TITLE
Microdata doesn't have a DOM API

### DIFF
--- a/webplat-wg.html
+++ b/webplat-wg.html
@@ -294,8 +294,7 @@
               <dd>Describing the use of ARIA attributes on HTML elements.</dd>
               <dt><a href="#844">Microdata</a></dt>
               <dd>Widely-used attributes on HTML elements to provide metadata, e.g. as Schema.org or 
-              Dublin Core.<br>
-                NOTE: The microdata DOM API is out of scope.</dd>
+              Dublin Core.</dd>
             </dl>
           </dd>
           <dt id="manifest"><a href="#1138">Manifest for Web 


### PR DESCRIPTION
fix #157

There is no obvious justification for a microdata DOM API, so whether it is in scope or not is irrelevant. On the other hand if browsers suddenly implemented one, e.g. based on the old specification for it, then it would be silly not to have it in scope.